### PR TITLE
Improve sorting of names for index

### DIFF
--- a/anthologize/anthology_xml.py
+++ b/anthologize/anthology_xml.py
@@ -48,15 +48,24 @@ def process(bibfilename, paperid):
         if field in ['author', 'editor']:
             if field in bibentry.persons:
                 for person in bibentry.persons[field]:
-                    node = etree.Element(field)
-                    first = etree.Element('first')
-                    first.text = latex.latex_to_unicode(' '.join(person.bibtex_first_names))
-                    node.append(first)
-                    last = etree.Element('last')
-                    last.text = latex.latex_to_unicode(' '.join(person.prelast_names +
+                    first_text = latex.latex_to_unicode(' '.join(person.bibtex_first_names))
+                    last_text = latex.latex_to_unicode(' '.join(person.prelast_names +
                                                                 person.last_names))
                     if person.lineage_names:
-                        last.text += ', ' + ' '.join(person.lineage_names)
+                        last_text += ', ' + ' '.join(person.lineage_names)
+
+                    # Don't distinguish between authors that have only a first name
+                    # vs. authors that have only a last name; always make it a last name.
+                    if last_text.strip() in ['', '-']: # Some START users have '-' for null
+                        last_text = first_text
+                        first_text = ''
+                        
+                    node = etree.Element(field)
+                    first = etree.Element('first')
+                    first.text = first_text
+                    node.append(first)
+                    last = etree.Element('last')
+                    last.text = last_text
                     node.append(last)
                     paper.append(node)
         else:

--- a/bin/manage-db.pl
+++ b/bin/manage-db.pl
@@ -265,6 +265,15 @@ sub include {
         # decompose Unicode accents (to be removed later)
         $author_clean = NFKD($author_clean);
         
+        # decompose a few that NFKD doesn't get
+        # http://zderadicka.eu/removing-diacritics-marks-from-strings/
+        $author_clean =~ tr/ĐđĦħıȷŁłØøŦŧ/DdHhijLlOoTt/;
+        $author_clean =~ s/Æ/AE/g; $author_clean =~ s/æ/ae/g;
+        $author_clean =~ s/Œ/OE/g; $author_clean =~ s/œ/oe/g;
+        $author_clean =~ s/ẞ/SS/g; $author_clean =~ s/ß/ss/g;
+        $author_clean =~ s/Þ/Th/g; $author_clean =~ s/þ/th/g;
+        $author_clean =~ s/Ŋ/Ng/g; $author_clean =~ s/ŋ/ng/g;
+        
         # remove TeX accents
         # this is similar to what BibTeX does
         # http://tug.ctan.org/info/bibtex/tamethebeast/ttb_en.pdf, page 22, 34
@@ -273,7 +282,8 @@ sub include {
         # there are some cases where a control character won't eat spaces,
         # but I think they are unlikely in an author name
         $author_clean =~ s/\\([A-Za-z]+|.)\s*//g;
-        $author_clean =~ s/[^A-Za-z0-9, ]//g;
+        # BibTeX keeps only ASCII alphanumerics; keep all Unicode alphanumerics
+        $author_clean =~ s/[^\pL\d, ]//gu;
         
         $author_clean =~ s/\s+/ /g;
         $author_clean =~ s/^\s*//g;


### PR DESCRIPTION
In manage-db.pl, when index entries are being output, we need to convert all names to their closest ASCII equivalents, because that's all that makeindex knows how to sort. Unicode decomposition is able to get most of them, but misses a few cases. This adds some of the common cases. It also makes the sort keys less wrong for any cases that are still missed (by preserving instead of deleting characters that are missed).
