### PR TITLE
Fix broken HTML generation scripts with older Perl versions

### DIFF
--- a/bin/db-to-html.pl
+++ b/bin/db-to-html.pl
@@ -10,6 +10,7 @@ use utf8;
 use open qw(:std :utf8);
 
 use Unicode::Normalize;
+use charnames ":full";
 use HTML::Entities;
 
 while (<>) {


### PR DESCRIPTION
We are seeing lots of errors like
```
Constant(\N{COMBINING ACUTE ACCENT}): $^H{charnames} is not defined at /hdc/var/www/v3/naacl2019/www/tutorials2019/manager/aclpub/all/bin/db-to-html.pl line 71, near "$1"
```
which is breaking the HTML generation scripts. I think this is because of the older Perl being used on the server. This PR adds a single line that is supposed to enable Unicode character names.
