### PR TITLE
Use curl instead of wget

### DIFF
--- a/anthology/download-proceedings.sh
+++ b/anthology/download-proceedings.sh
@@ -21,6 +21,6 @@ cat $start_urls_file | while read url; do
   echo "Downloading $url -> data/$acronym"
   [[ ! -d "data/$acronym" ]] && mkdir -p data/$acronym
   (cd data/$acronym &&
-  curl -sS --fail -O $url/pub/aclpub/proceedings.tgz &&
+  curl -sS --fail --insecure -O $url/pub/aclpub/proceedings.tgz &&
   tar -zxf proceedings.tgz)
 done

--- a/anthology/download-proceedings.sh
+++ b/anthology/download-proceedings.sh
@@ -20,7 +20,7 @@ cat $start_urls_file | while read url; do
   fi
   echo "Downloading $url -> data/$acronym"
   [[ ! -d "data/$acronym" ]] && mkdir -p data/$acronym
-  (cd data/$acronym
-  wget -N --no-check-certificate $url/pub/aclpub/proceedings.tgz
+  (cd data/$acronym &&
+  curl -sS --fail -O $url/pub/aclpub/proceedings.tgz &&
   tar -zxf proceedings.tgz)
 done


### PR DESCRIPTION
I'd recommend `curl` instead of `wget` since it's available on more platforms, e.g., OS X. Also, I added `&&` to the commands so that `tar` doesn't execute if the file is not downloaded. Useful when not all proceedings are complete yet.