### PR TITLE
Simplifies titlepage code

### DIFF
--- a/templates/proceedings/titlepage.tex
+++ b/templates/proceedings/titlepage.tex
@@ -20,27 +20,17 @@
 \begin{document}
 
   \begin{center}
-  \LARGE ACL 2020 \\
-  \vspace*{55mm}
-    {\bf
-    %\Huge
-    \LARGE
-    % \fontsize{38}{46}\selectfont
-     The 58th Annual Meeting of the \\
-     Association for Computational Linguistics\\
-    \hspace*{1cm}\\ \hspace*{1cm} \\
-    \hspace*{1cm} \\ \hspace*{1cm}\\
-    \hspace*{1cm}\\
-    \vspace{2cm}
-    %\Huge
-    \LARGE
+  \LARGE
+  ACL 2020 \\
+  \vfill
+  {\bf
+    The 58th Annual Meeting of the \\
+    Association for Computational Linguistics\\
+    \vfill
     Proceedings of the Conference\\
-    \vspace{2cm}
-    \hspace*{1cm}} \\ % Full Volume
-    %\vspace{75mm}
-    \vspace{43mm}
-    \LARGE
-    July 5 - 10, 2020
+  }
+  \vfill
+  July 5 - 10, 2020
   \end{center}
 
 \end{document}


### PR DESCRIPTION
There were a bunch of redundant \LARGEs and confusing \hspaces. It seems much simpler to me (and in my tests looks almost identical) to just use \vfill.