### PR TITLE
Makes papersizes and topmargins consistent across templates

### DIFF
--- a/templates/proceedings/just-program.tex
+++ b/templates/proceedings/just-program.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt]{article}
+\documentclass[11pt,a4paper]{article}
 \usepackage[utf8]{inputenc} 
 \usepackage[T1]{fontenc} % fonts to encode unicode
 \usepackage{times}

--- a/templates/proceedings/just-toc.tex
+++ b/templates/proceedings/just-toc.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt]{article}
+\documentclass[11pt,a4paper]{article}
 \usepackage[utf8]{inputenc} 
 \usepackage[T1]{fontenc} % fonts to encode unicode
 \usepackage{times}

--- a/templates/proceedings/organizers.tex
+++ b/templates/proceedings/organizers.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt]{article}
+\documentclass[11pt,a4paper]{article}
 \usepackage[utf8]{inputenc} 
 \usepackage[T1]{fontenc} % fonts to encode unicode
 \usepackage{times}

--- a/templates/proceedings/preface.tex
+++ b/templates/proceedings/preface.tex
@@ -1,4 +1,4 @@
-\documentclass[11pt]{article}
+\documentclass[11pt,a4paper]{article}
 \usepackage[utf8]{inputenc} 
 \usepackage[T1]{fontenc} % fonts to encode unicode
 \usepackage{times}

--- a/templates/proceedings/titlepage.tex
+++ b/templates/proceedings/titlepage.tex
@@ -1,10 +1,10 @@
-\documentclass[11pt]{article}
+\documentclass[11pt,a4paper]{article}
 \usepackage{times}
 
 \sloppy
 \hyphenpenalty 10000
 
-\setlength\topmargin{0.2cm} \setlength\oddsidemargin{-0cm}
+\setlength\topmargin{-5mm} \setlength\oddsidemargin{-0cm}
 \setlength\textheight{24.7cm} \setlength\textwidth{16cm}
 \setlength\columnsep{0.6cm}  \newlength\titlebox \setlength\titlebox{2.00in}
 \setlength\headheight{5pt}   \setlength\headsep{0pt}


### PR DESCRIPTION
I believe we want titlepage.tex, copyright.tex, preface.tex, organizers.tex, etc. to all have the same paper size. This also resolves an issue I've seen many times in proceedings where the preface and/or organizers go into the margin.