### PR TITLE
Delay redefinition of \maketitle for compatibility with bidi package

### DIFF
--- a/templates/latex/acl.sty
+++ b/templates/latex/acl.sty
@@ -152,6 +152,7 @@
     \end{tabular}}
 
 % Mostly taken from deproc.
+\AtBeginDocument{
 \def\maketitle{\par
  \begingroup
    \def\thefootnote{\fnsymbol{footnote}}
@@ -178,6 +179,7 @@
     \hfil\hfil\egroup}
   \vskip 0.3in plus 2fil minus 0.1in
 }}
+}
 
 % margins and font size for abstract
 \renewenvironment{abstract}%


### PR DESCRIPTION
When you use acl.sty with the bidi package (e.g., with polyglossia and hebrew), the title gets reset to the default title:
https://twitter.com/anas_ant/status/1447947055574306820

The fix is to wrap the redefinition of \maketitle inside \AtBeginDocument:
https://tex.stackexchange.com/questions/388152/incompatibility-of-sagej-and-polyglossia-hebrew-no-custom-titlepage
